### PR TITLE
Add catchall table to postfix plugin

### DIFF
--- a/postfix/admin/systems/services/postfix/class_servicePostfix.inc
+++ b/postfix/admin/systems/services/postfix/class_servicePostfix.inc
@@ -19,6 +19,26 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+class CatchallDomainAttribute extends StringAttribute
+{
+  function fixPostValue ($value)
+  {
+    /* prepend '@' for postfix catchall mapping */
+    if ($value) {
+      return '@'.parent::fixPostValue($value);
+    } else {
+      return $value;
+    }
+  }
+
+  function displayValue ($value)
+  {
+    /* remove initial '@' from display */
+    return '@' == substr($value, 0, 1) ? substr($value, 1) : $value;
+  }
+}
+
+
 class servicePostfix extends simpleService
 {
   var $objectclasses = array('fdPostfixServer');
@@ -95,6 +115,14 @@ class servicePostfix extends simpleService
                 '%s:%s', '', ''
               )
             )
+          ),
+          new SubNodesAttribute (
+            _('Catchall table'), _('Catchall table'),
+            'fdPostfixCatchallTable', 'fdPostfixCatchallTable',
+            array(
+              new CatchallDomainAttribute ('Domain', '', 'fdCatchallTableDomain'),
+              new MailAttribute ('Recipient', '', 'fdCatchallTableRecipient')
+            )
           )
         )
       ),
@@ -145,6 +173,7 @@ class servicePostfix extends simpleService
     global $config;
     $errors = parent::ldap_save();
     $this->attributesAccess['fdPostfixTransportTable']->postLdapSave($config->get_ldap_link());
+    $this->attributesAccess['fdPostfixCatchallTable']->postLdapSave($config->get_ldap_link());
     return $errors;
   }
 }

--- a/postfix/contrib/openldap/postfix-fd.schema
+++ b/postfix/contrib/openldap/postfix-fd.schema
@@ -72,6 +72,18 @@ attributetype ( 1.3.6.1.4.1.38414.10.12.2 NAME 'fdTransportTableRule'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
   SINGLE-VALUE)
 
+attributetype ( 1.3.6.1.4.1.38414.10.11.12 NAME 'fdCatchallTableDomain'
+  DESC 'FusionDirectory - postfix catchall table domain'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE)
+
+attributetype ( 1.3.6.1.4.1.38414.10.11.13 NAME 'fdCatchallTableRecipient'
+  DESC 'FusionDirectory - postfix catchall table recipient'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE)
+
 # Postfix Server description
 objectclass (1.3.6.1.4.1.38414.10.2.3 NAME 'fdPostfixServer' SUP top AUXILIARY
   DESC 'FusionDirectory - Postfix server definition'
@@ -85,4 +97,9 @@ objectclass (1.3.6.1.4.1.38414.10.2.3 NAME 'fdPostfixServer' SUP top AUXILIARY
 objectclass (1.3.6.1.4.1.38414.10.2.4 NAME 'fdPostfixTransportTable'
   DESC 'FusionDirectory - Postfix transport table line'
   MUST ( fdTransportTableMatch $ fdTransportTableRule )
+  MAY  (  ) )
+
+objectclass (1.3.6.1.4.1.38414.10.2.6 NAME 'fdPostfixCatchallTable'
+  DESC 'FusionDirectory - Postfix catchall table line'
+  MUST ( fdCatchallTableDomain $ fdCatchallTableRecipient )
   MAY  (  ) )


### PR DESCRIPTION
Alternative implementation of fix for #9. This one adds a catchall table to the postfix plugin and the schema update to store the data.

Note that is automatically prepends a '@' to the domain names so the information in the directory is what postfix needs to match against. To make this work with postfix, you add an additional table to virtual_alias_maps like:

    server_host = ldap.example.com
    search_base = cn=<servername>,ou=servers,ou=systems,dc=example,dc=com
    query_filter = (fdCatchallTableDomain=%s)
    result_attribute = fdCatchallTableRecipient 

