### PR TITLE
removes empty memberUid in case of nested groups

### DIFF
--- a/mixedgroups/admin/ogroups/mixedgroups/class_mixedGroup.inc
+++ b/mixedgroups/admin/ogroups/mixedgroups/class_mixedGroup.inc
@@ -146,7 +146,9 @@ class mixedGroup extends simplePlugin
     foreach ($members as $dn) {
       $ldap->cat($dn, array('uid'));
       $attrs = $ldap->fetch();
-      $memberUid[] = $attrs['uid'][0];
+      if (isset($attrs['uid'][0])) {
+        $memberUid[] = $attrs['uid'][0];
+      }
     }
     $this->memberUid = $memberUid;
 


### PR DESCRIPTION
Background to this patch in https://github.com/fusiondirectory/fusiondirectory-plugins/pull/14