### PR TITLE
PR for adding features on application plugins

### DIFF
--- a/applications/admin/applications/class_webApplication.inc
+++ b/applications/admin/applications/class_webApplication.inc
@@ -79,14 +79,32 @@ class webApplication extends simplePlugin
       'roles' => array(
         'name'  => _('Rôles'),
         'attrs' => array(
-          new SetAttribute(
-            new StringAttribute(
-              _('AvailablesRoles'), _('Roles availables on application'),
-              'fdApplicationAvailablesRoles', FALSE
+          new OrderedArrayAttribute(
+            new PipeSeparatedCompositeAttribute(
+              _('Roles used per application'),
+              'fdApplicationAvailablesRoles',
+              array(
+                new StringAttribute(
+                  _('Code'),
+                  _('Short of this role'),
+                  'RoleShortCode',
+                  TRUE),
+                new StringAttribute(
+                  _('Description'),
+                  _('Description of this Role'),
+                  'RoleDesc',
+                  FALSE),
+                )
+              ),
+              // no order
+              FALSE,
+              array(),
+              // edit button
+              TRUE
             )
           ),
         )
-      ),
+      //),
       
     );
   }

--- a/applications/admin/applications/class_webApplication.inc
+++ b/applications/admin/applications/class_webApplication.inc
@@ -61,6 +61,7 @@ class webApplication extends simplePlugin
           ),
         )
       ),
+
       'icon' => array(
         'name'  => _('Icon'),
         'attrs' => array(
@@ -75,6 +76,16 @@ class webApplication extends simplePlugin
           ),
         )
       ),
+      'roles' => array(
+        'name'  => _('Rôles'),
+        'attrs' => array(
+          new ArrayAttribute (
+            _('AvailablesRoles'), _('Roles availables on application'),
+            'fdApplicationAvailablesRoles', FALSE
+          ),
+        )
+      ),
+      
     );
   }
 }

--- a/applications/admin/applications/class_webApplication.inc
+++ b/applications/admin/applications/class_webApplication.inc
@@ -77,22 +77,22 @@ class webApplication extends simplePlugin
         )
       ),
       'roles' => array(
-	      'name'  => _('Profiles'),
-	      'class' => array('fullwidth'),
+      'name'  => _('Profiles'),
+      'class' => array('fullwidth'),
         'attrs' => array(
           new OrderedArrayAttribute(
 	    new PipeSeparatedCompositeAttribute(
-              _('Profiles availables'),
+              _('Availables profiles'),
               'fdApplicationAvailablesProfiles',
               array(
                 new StringAttribute(
                   _('Code'),
-                  _('Short of this role'),
+                  _('Short code of this profile'),
                   'RoleShortCode',
                   TRUE),
                 new StringAttribute(
                   _('Description'),
-                  _('Description of this Role'),
+                  _('Description of this profile'),
                   'RoleDesc',
                   FALSE),
                 )

--- a/applications/admin/applications/class_webApplication.inc
+++ b/applications/admin/applications/class_webApplication.inc
@@ -79,9 +79,11 @@ class webApplication extends simplePlugin
       'roles' => array(
         'name'  => _('Rôles'),
         'attrs' => array(
-          new ArrayAttribute (
-            _('AvailablesRoles'), _('Roles availables on application'),
-            'fdApplicationAvailablesRoles', FALSE
+          new SetAttribute(
+            new StringAttribute(
+              _('AvailablesRoles'), _('Roles availables on application'),
+              'fdApplicationAvailablesRoles', FALSE
+            )
           ),
         )
       ),

--- a/applications/admin/applications/class_webApplication.inc
+++ b/applications/admin/applications/class_webApplication.inc
@@ -77,12 +77,13 @@ class webApplication extends simplePlugin
         )
       ),
       'roles' => array(
-        'name'  => _('Rôles'),
+	      'name'  => _('Profiles'),
+	      'class' => array('fullwidth'),
         'attrs' => array(
           new OrderedArrayAttribute(
-            new PipeSeparatedCompositeAttribute(
-              _('Roles used per application'),
-              'fdApplicationAvailablesRoles',
+	    new PipeSeparatedCompositeAttribute(
+              _('Profiles availables'),
+              'fdApplicationAvailablesProfiles',
               array(
                 new StringAttribute(
                   _('Code'),

--- a/applications/contrib/openldap/applications-fd.schema
+++ b/applications/contrib/openldap/applications-fd.schema
@@ -39,6 +39,21 @@ attributetype ( 1.3.6.1.4.1.38414.46.10.6 NAME 'fdApplicationFlags'
   SUBSTR caseIgnoreIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
 
+# roles APP_ROLES per app
+attributetype ( 1.3.6.1.4.1.38414.46.10.7 NAME 'fdApplicationAvailablesRoles'
+  DESC 'FusionDirectory - Specifies the application Roles available per application - informations affects users'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+### list of roles per user
+attributetype ( 1.3.6.1.4.1.38414.46.10.8 NAME 'fdApplicationRoles'
+  DESC 'FusionDirectory - Specifies the application Roles available per application - informations affects users'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+
 attributetype ( 1.3.6.1.4.1.38414.46.11.1 NAME 'fdApplicationAllowed'
   DESC 'FusionDirectory - Applications which this user/role/group is allowed to access'
   EQUALITY caseIgnoreMatch
@@ -55,10 +70,18 @@ objectclass ( 1.3.6.1.4.1.38414.46.2.1 NAME 'fdDesktopApplication'
 objectclass ( 1.3.6.1.4.1.38414.46.2.2 NAME 'fdWebApplication'
   DESC 'FusionDirectory - Web Applications storage for FusionDirectory'
   MUST ( cn $ labeledURI )
-  MAY ( fdApplicationTitle $ fdApplicationImage $ fdApplicationImageLocation $ description ))
+  MAY ( fdApplicationTitle $ fdApplicationImage $ fdApplicationImageLocation $ description $ fdApplicationAvailablesRoles))
 
 objectclass ( 1.3.6.1.4.1.38414.46.2.3 NAME 'fdApplicationRights'
   SUP top AUXILIARY
   DESC 'FusionDirectory - Applications user rights'
   MUST ( fdApplicationAllowed )
   MAY (  ))
+
+#### user class
+objectclass ( 1.3.6.1.4.1.38414.46.2.4 NAME 'fdApplicationAccount'
+  SUP top AUXILIARY
+  DESC 'FusionDirectory - Class for affecting application clas and roles'
+  MUST ( fdApplicationRoles )
+  MAY (  ))
+

--- a/applications/contrib/openldap/applications-fd.schema
+++ b/applications/contrib/openldap/applications-fd.schema
@@ -40,15 +40,15 @@ attributetype ( 1.3.6.1.4.1.38414.46.10.6 NAME 'fdApplicationFlags'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
 
 # roles APP_ROLES per app
-attributetype ( 1.3.6.1.4.1.38414.46.10.7 NAME 'fdApplicationAvailablesRoles'
-  DESC 'FusionDirectory - Specifies the application Roles available per application - informations affects users'
+attributetype ( 1.3.6.1.4.1.38414.46.10.7 NAME 'fdApplicationAvailablesProfiles'
+  DESC 'FusionDirectory - Specifies the application profiles available per application - informations affects applications'
   EQUALITY caseIgnoreIA5Match
   SUBSTR caseIgnoreIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
 
 ### list of roles per user
-attributetype ( 1.3.6.1.4.1.38414.46.10.8 NAME 'fdApplicationRoles'
-  DESC 'FusionDirectory - Specifies the application Roles available per application - informations affects users'
+attributetype ( 1.3.6.1.4.1.38414.46.10.8 NAME 'fdApplicationProfiles'
+  DESC 'FusionDirectory - Specifies the application profiles available per application - informations affects users'
   EQUALITY caseIgnoreIA5Match
   SUBSTR caseIgnoreIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
@@ -70,7 +70,7 @@ objectclass ( 1.3.6.1.4.1.38414.46.2.1 NAME 'fdDesktopApplication'
 objectclass ( 1.3.6.1.4.1.38414.46.2.2 NAME 'fdWebApplication'
   DESC 'FusionDirectory - Web Applications storage for FusionDirectory'
   MUST ( cn $ labeledURI )
-  MAY ( fdApplicationTitle $ fdApplicationImage $ fdApplicationImageLocation $ description $ fdApplicationAvailablesRoles))
+  MAY ( fdApplicationTitle $ fdApplicationImage $ fdApplicationImageLocation $ description $ fdApplicationAvailablesProfiles))
 
 objectclass ( 1.3.6.1.4.1.38414.46.2.3 NAME 'fdApplicationRights'
   SUP top AUXILIARY
@@ -81,7 +81,7 @@ objectclass ( 1.3.6.1.4.1.38414.46.2.3 NAME 'fdApplicationRights'
 #### user class
 objectclass ( 1.3.6.1.4.1.38414.46.2.4 NAME 'fdApplicationAccount'
   SUP top AUXILIARY
-  DESC 'FusionDirectory - Class for affecting application clas and roles'
-  MUST ( fdApplicationRoles )
+  DESC 'FusionDirectory - Class for affecting application profiles to user'
+  MUST ( fdApplicationProfiles )
   MAY (  ))
 

--- a/applications/locale/en/fusiondirectory.po
+++ b/applications/locale/en/fusiondirectory.po
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Profiles"
 msgstr ""
 
-msgid "Profiles availables"
+msgid "Availables profiles"
 msgstr ""
 
 msgid "Code"
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-msgid "Profile per Application"
+msgid "Profile per application"
 msgstr ""
 
-msgid "Profiles per account"
+msgid "User profile per applications"
 msgstr ""
 
 msgid "Profiles per each applications"
 msgstr ""
 
-msgid "Applications Profiles - Profiles available for each applications"
+msgid "Profiles - Availables profiles each applications"
 msgstr ""
 

--- a/applications/locale/en/fusiondirectory.po
+++ b/applications/locale/en/fusiondirectory.po
@@ -221,3 +221,34 @@ msgstr ""
 #: admin/roles/class_applicationRights.inc:49
 msgid "The applications users with this role are allowed to launch"
 msgstr ""
+
+msgid "Profiles"
+msgstr ""
+
+msgid "Profiles availables"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Short code of this profile"
+msgstr ""
+
+msgid "Description of this profile"
+msgstr ""
+
+msgid "Profile"
+msgstr ""
+
+msgid "Profile per Application"
+msgstr ""
+
+msgid "Profiles per account"
+msgstr ""
+
+msgid "Profiles per each applications"
+msgstr ""
+
+msgid "Applications Profiles - Profiles available for each applications"
+msgstr ""
+

--- a/applications/locale/fr/fusiondirectory.po
+++ b/applications/locale/fr/fusiondirectory.po
@@ -223,3 +223,33 @@ msgstr "Selon autorisation"
 #: config/applications/class_applicationsPluginConfig.inc:56
 msgid "All"
 msgstr "Toutes"
+
+msgid "Profiles"
+msgstr "Profils"
+
+msgid "Profiles availables"
+msgstr "Profils disponibles"
+
+msgid "Code"
+msgstr "Code" 
+
+msgid "Short code of this profile"
+msgstr "Code court pour ce profil"
+
+msgid "Description of this profile"
+msgstr "Description de ce profil"
+
+msgid "Profile"
+msgstr "Profil"
+
+msgid "Profile per Application"
+msgstr "Profil par applications"
+
+msgid "Profiles per account"
+msgstr "Profile par compte"
+
+msgid "Profiles per each applications"
+msgstr "Profil pour chaque applications"
+
+msgid "Applications Profiles - Profiles available for each applications"
+msgstr "Profils utilisateurs - profils disponible pour chaque applications"

--- a/applications/locale/fr/fusiondirectory.po
+++ b/applications/locale/fr/fusiondirectory.po
@@ -227,29 +227,29 @@ msgstr "Toutes"
 msgid "Profiles"
 msgstr "Profils"
 
-msgid "Profiles availables"
+msgid "Availables profiles"
 msgstr "Profils disponibles"
 
 msgid "Code"
-msgstr "Code" 
+msgstr "Code"
 
 msgid "Short code of this profile"
-msgstr "Code court pour ce profil"
+msgstr "Code court du profil"
 
 msgid "Description of this profile"
-msgstr "Description de ce profil"
+msgstr "Description du profil"
 
 msgid "Profile"
 msgstr "Profil"
 
-msgid "Profile per Application"
+msgid "Profile per application"
 msgstr "Profil par applications"
 
-msgid "Profiles per account"
-msgstr "Profile par compte"
+msgid "User profile per applications"
+msgstr "Profil utilisateur par applications"
 
 msgid "Profiles per each applications"
-msgstr "Profil pour chaque applications"
+msgstr "Profils pour chaque utilisateur"
 
-msgid "Applications Profiles - Profiles available for each applications"
-msgstr "Profils utilisateurs - profils disponible pour chaque applications"
+msgid "Profiles - Availables profiles each applications"
+msgstr "Profils - Profils utilisateurs disponibles par applications "

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -151,7 +151,7 @@ class applicationAccount extends simplePlugin
   {
     return array(
       'plShortName'     => _('Profile'),
-      'plDescription'   => _('Profile per Application'),
+      'plDescription'   => _('Profile per application'),
       'plIcon'          => 'geticon.php?context=types&icon=application&size=48',
       'plSmallIcon'     => 'geticon.php?context=types&icon=application&size=16',
       'plDepends'       => array(),
@@ -175,7 +175,8 @@ class applicationAccount extends simplePlugin
 
     return array (
       'main' => array (
-        'name'  => _('Applications account'),
+	'name'  => _('User profile per applications'),
+        'class' => array('fullwidth'),
 	'attrs' => array (
           new OrderedArrayAttribute(
             new PipeSeparatedCompositeAttribute(
@@ -183,7 +184,7 @@ class applicationAccount extends simplePlugin
               'fdApplicationProfiles',
               array(
                 new ApplicationSelectAttribute(
-                  _('Profiles'), _('Applications Profiles - Profiles available for each applications'),
+                  _('Profiles'), _('Profiles - Availables profiles for each applications'),
                   'fdApplicationProfiles', TRUE, 'webApplication'
                   ),
                 )

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -21,7 +21,7 @@
 
 
 /*!
-  \brief   seafile plugin
+  \brief   application plugin
 
   This class provides the functionality to read and write all informations 
   for creating / editing / deleting remote seafiel account.
@@ -51,7 +51,6 @@ class ApplicationSelectAttribute extends CompositeAttribute
     $ldap->cd($config->current['BASE']);
     $ldap->search('(objectClass=fdWebApplication)', array('cn', 'fdApplicationAvailablesRoles'));
 
-    //parcours des ebregistremens
     while ($attrs = $ldap->fetch()) {
       if (isset($attrs['cn'][0])) {
 	 $app = $attrs['cn'][0];
@@ -64,12 +63,9 @@ class ApplicationSelectAttribute extends CompositeAttribute
 	        	
 	}
       }
-      $allchoices[$app]=array($allRolesCode,$allRolesDesc);
+      $this->applicationChoices[$app]=array($allRolesCode,$allRolesDesc);
     }
     
-    /* a requeter depsui la bracnhe */
-    $this->applicationChoices = $allchoices;
-
     if (!$required) {
       $this->applicationChoices[''] = array(array(''), array(_('None')));
     }
@@ -147,7 +143,6 @@ class applicationAccount extends simplePlugin
 {
   var $displayHeader  = TRUE;
   var $objectclasses  = array('fdApplicationAccount');
-  var $myclient	= '';
   
   private $mainSectionAttrs = array();
 
@@ -155,10 +150,10 @@ class applicationAccount extends simplePlugin
   static function plInfo()
   {
     return array(
-      'plShortName'     => _('Applications'),
-      'plDescription'   => _('applications settings'),
-      'plIcon'          => 'geticon.php?context=applications&icon=applications&size=48',
-      'plSmallIcon'     => 'geticon.php?context=applications&icon=applications&size=16',
+      'plShortName'     => _('Profile'),
+      'plDescription'   => _('Profile per Application'),
+      'plIcon'          => 'geticon.php?context=types&icon=application&size=48',
+      'plSmallIcon'     => 'geticon.php?context=types&icon=application&size=16',
       'plDepends'       => array(),
       'plSelfModify'    => FALSE,
       'plPriority'      => 4,
@@ -184,11 +179,11 @@ class applicationAccount extends simplePlugin
 	'attrs' => array (
           new OrderedArrayAttribute(
             new PipeSeparatedCompositeAttribute(
-              _('Roles per each applications'),
+              _('Profiles per each applications'),
               'fdApplicationRoles',
               array(
                 new ApplicationSelectAttribute(
-                  _('Roles'), _('Applications Roles - roles available for each applications'),
+                  _('Profiles'), _('Applications Profiles - Profiles available for each applications'),
                   'fdApplicationRoles', TRUE, 'webApplication'
                   ),
                 )
@@ -210,25 +205,10 @@ class applicationAccount extends simplePlugin
   {
     $smarty = get_smarty();
 
-    #
-    # Fetch Seafile Server
-    #
     global $config;
 
     return parent::execute();
   }
-  
-
-
-
-  function prepare_save(){
-	parent::prepare_save();
-	global $config;
-	
-}
-
-
-
 
 }
 

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -49,14 +49,14 @@ class ApplicationSelectAttribute extends CompositeAttribute
     /* list of entity stored in LDAP tree */
     $ldap = $config->get_ldap_link();
     $ldap->cd($config->current['BASE']);
-    $ldap->search('(objectClass=fdWebApplication)', array('cn', 'fdApplicationAvailablesRoles'));
+    $ldap->search('(objectClass=fdWebApplication)', array('cn', 'fdApplicationAvailablesProfiles'));
 
     while ($attrs = $ldap->fetch()) {
       if (isset($attrs['cn'][0])) {
 	 $app = $attrs['cn'][0];
 	 $allRolesCode=[];
 	 $allRolesDesc=[];
-	foreach($attrs['fdApplicationAvailablesRoles'] as $val){
+	foreach($attrs['fdApplicationAvailablesProfiles'] as $val){
 		$splitRoles=explode('|',$val);
 		$allRolesCode[]=$splitRoles[0];
 		$allRolesDesc[]=$splitRoles[1];
@@ -180,11 +180,11 @@ class applicationAccount extends simplePlugin
           new OrderedArrayAttribute(
             new PipeSeparatedCompositeAttribute(
               _('Profiles per each applications'),
-              'fdApplicationRoles',
+              'fdApplicationProfiles',
               array(
                 new ApplicationSelectAttribute(
                   _('Profiles'), _('Applications Profiles - Profiles available for each applications'),
-                  'fdApplicationRoles', TRUE, 'webApplication'
+                  'fdApplicationProfiles', TRUE, 'webApplication'
                   ),
                 )
               ),

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -28,6 +28,121 @@
 
  */
  
+/* class for selection application */
+
+
+class ApplicationSelectAttribute extends CompositeAttribute
+{
+  protected $applicationChoices;
+
+  
+
+  function __construct($label, $description, $ldapName, $required, $filename, $acl = "")
+  {
+    $attributes = array(
+      new SelectAttribute('', '', $ldapName.'_app', $required),
+      new SelectAttribute('', '', $ldapName.'_role', $required)
+    );
+    parent::__construct($description, $ldapName, $attributes, '/^{(.*)}(.*)$/', '{%s}%s', $acl, $label);
+    $this->setLinearRendering(TRUE);
+
+//   $allApplications = objects::ls('webapplications',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
+//    var_dump($allApplications);
+
+//    $allchoices=array();
+//    $allRolesCode=array();
+//    $allRolesDesc=array();
+/*    foreach($allApplications as $key => $value){
+	    $allRolesCode=[];
+	    $allRolesDesc=[];
+	    foreach( $value['fdApplicationAvailablesRoles'] as $k => $v){
+		    $splitRoles=explode("|",$v);
+		    $allRolesCode[]=$splitRoles[0];
+		    $allRolesDesc[]=$splitRoles[1];
+	    }
+      	$allchoices[]=array($value =>array($allRolesCode,$allRolesDesc));
+    }
+
+    var_dump($allchoices); */
+
+
+
+    /*  $this->applicationChoices = FIXME: list des application */
+    /* a requeter depsui la bracnhe */
+
+    $this->applicationChoices = array("color" => array(array("blue", "red", "green"),array("bleu","rouge","vert")),
+	    			      "size" => array(array("small", "medium", "large"),array("petit","moyen","grand")));
+    
+    if (!$required) {
+      $this->applicationChoices[''] = array(array(''), array(_('None')));
+    }
+    $this->attributes[0]->setChoices(array_keys($this->applicationChoices));
+    $this->attributes[0]->setSubmitForm(TRUE);
+    $this->applicationUpdateSelect();
+    $this->setRequired($required);
+  }
+
+  protected function applicationUpdateSelect()
+  {
+    $prefix = $this->attributes[0]->getValue();
+    if (!isset($this->applicationChoices[$prefix])) {
+      $this->applicationChoices[$prefix] = array(array(), array());
+    }
+    $this->attributes[1]->setChoices($this->applicationChoices[$prefix][0], $this->applicationChoices[$prefix][1]);
+    $this->attributes[1]->setRequired($prefix != '');
+  }
+
+  function applyPostValue()
+  {
+    parent::applyPostValue();
+    $this->applicationUpdateSelect();
+  }
+
+  function setValue ($values)
+  {
+    if (!is_array($values)) {
+      $values = $this->inputValue($values);
+    }
+    $this->attributes[0]->setValue($values[0]);
+    $this->applicationUpdateSelect();
+    $this->attributes[1]->setValue($values[1]);
+  }
+
+  function resetToDefault ()
+  {
+    $this->attributes[0]->resetToDefault();
+    $this->applicationUpdateSelect();
+    $this->attributes[1]->resetToDefault();
+  }
+
+  function writeValues (array $values)
+  {
+    if ($values[0] == '') {
+      return '';
+    } else {
+      return parent::writeValues($values);
+    }
+  }
+
+  function displayValue($values)
+  {
+    if (!is_array($values)) {
+      $values = $this->inputValue($values);
+    }
+    $this->setValue($values);
+    $v1 = $this->attributes[0]->displayValue($values[0]);
+    $choices2 = $this->attributes[1]->getDisplayChoices();
+    if (isset($choices2[$values[1]])) {
+      $v2 = $choices2[$values[1]];
+      } else {
+      $v2 = $values[1];
+    }
+    return ($v1 == '' ? $v2 : $v1.': '.$v2);
+  }
+}
+
+
+
  
 
 
@@ -44,8 +159,8 @@ class applicationAccount extends simplePlugin
     return array(
       'plShortName'     => _('Applications'),
       'plDescription'   => _('applications settings'),
-      'plIcon'          => 'geticon.php?context=applications&icon=seafile&size=48',
-      'plSmallIcon'     => 'geticon.php?context=applications&icon=seafile&size=16',
+      'plIcon'          => 'geticon.php?context=applications&icon=applications&size=48',
+      'plSmallIcon'     => 'geticon.php?context=applications&icon=applications&size=16',
       'plDepends'       => array(),
       'plSelfModify'    => FALSE,
       'plPriority'      => 4,
@@ -64,21 +179,27 @@ class applicationAccount extends simplePlugin
     return array (
       'main' => array (
         'name'  => _('Applications account'),
-        'attrs' => array (
-      
-          new CompositeAttribute (
-            _('Informations for ftp login'),
-              'ftpLoginInfo',
-            array(
-              new StringAttribute (_('Login'),    _('Login for FTP'),     'ftpLogin'),
-              new StringAttribute (_('Password'), _('Password for FTP'),  'ftpPassword'),
-              new StringAttribute (_('Host'),     _('Host for FTP'),      'ftpHost'),
-              new IntAttribute    (_('Port'),     _('Port for FTP'),      'ftpPort', FALSE, 0, FALSE, 21),
-            ),
-          'ftp://%[^@:]:%[^@:]@%[^@:]:%d', // sscanf format
-          'ftp://%s:%s@%s:%d'              // sprintf format
+	'attrs' => array (
+          new OrderedArrayAttribute(
+            new PipeSeparatedCompositeAttribute(
+              _('Roles per each applications'),
+              'fdApplicationRoles',
+              array(
+                new applicationSelectAttribute(
+                  _('Roles'), _('Applications Roles - roles available for each applications'),
+                  'fdApplicationRoles', FALSE, 'webApplication'
+                  ),
+                )
+              ),
+              // no order
+              FALSE,
+              array(),
+              // edit button
+              TRUE
+            )
+          )
         ),
-      ),
+      
     );
   }
 

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -35,8 +35,6 @@ class ApplicationSelectAttribute extends CompositeAttribute
 {
   protected $applicationChoices;
 
-  //global $config; 
-
   function __construct($label, $description, $ldapName, $required, $filename, $acl = "")
   {
     global $config;
@@ -68,41 +66,10 @@ class ApplicationSelectAttribute extends CompositeAttribute
       }
       $allchoices[$app]=array($allRolesCode,$allRolesDesc);
     }
-    print_r($allchoices);
-    print_r("<br>");
-
-   // $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
-   //$allApplications = objects::ls('webApplication');
-    //var_dump($allApplications);
-    //var_dump(objects);
-
-//    $allchoices=array();
-//    $allRolesCode=array();
-//    $allRolesDesc=array();
-/*    foreach($allApplications as $key => $value){
-	    $allRolesCode=[];
-	    $allRolesDesc=[];
-	    foreach( $value['fdApplicationAvailablesRoles'] as $k => $v){
-		    $splitRoles=explode("|",$v);
-		    $allRolesCode[]=$splitRoles[0];
-		    $allRolesDesc[]=$splitRoles[1];
-	    }
-      	$allchoices[]=array($value =>array($allRolesCode,$allRolesDesc));
-    }
-
-    var_dump($allchoices); */
-
-
-
-    /*  $this->applicationChoices = FIXME: list des application */
+    
     /* a requeter depsui la bracnhe */
     $this->applicationChoices = $allchoices;
 
-    //$this->applicationChoices = array("color" => array(array("blue", "red", "green"),array("bleu","rouge","vert")),
-//	    "size" => array(array("small", "medium", "large"),array("petit","moyen","grand")));
-
-    print_r($this->applicationChoices);
-    
     if (!$required) {
       $this->applicationChoices[''] = array(array(''), array(_('None')));
     }
@@ -185,43 +152,6 @@ class applicationAccount extends simplePlugin
   private $mainSectionAttrs = array();
 
 
-/*
-  function getApplicationsRoles()
-  {
-    $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
-    //var_dump($allApplications);
-
-    $allchoices=array();
-    $allRolesCode=array();
-    $allRolesDesc=array();
-    foreach($allApplications as $key => $value){
-            $allRolesCode=[];
-	    $allRolesDesc=[];
-	    foreach( $value['fdApplicationAvailablesRoles'] as $k => $v){
-		    //print("val : ".$v);
-                    $splitRoles=explode("|",$v);
-                    $allRolesCode[]=$splitRoles[0];
-		    $allRolesDesc[]=$splitRoles[1];
-		    //print("\nval :".$splitRoles[0]. " => ".$splitRoles[1]);
-	    }
-//	print("<br>");
-//	    var_dump($allRolesCode);
-//	    print("<br>");
-//	var_dump($allRolesDesc);
-        $allchoices[]=array($value['cn'] =>array($allRolesCode,$allRolesDesc));
-    }
-
-    return $allchoices;
-    //var_dump($allchoices);
-    /* Get List of server with LDAP service */
-/*    return objects::ls('server', NULL, NULL, '(objectClass=goLdapServer)');*/
-/*
-}
-*/
-  
-
-
-  
   static function plInfo()
   {
     return array(

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -35,19 +35,24 @@ class ApplicationSelectAttribute extends CompositeAttribute
 {
   protected $applicationChoices;
 
-  
+  //global $config; 
 
   function __construct($label, $description, $ldapName, $required, $filename, $acl = "")
   {
+    //global $config;
     $attributes = array(
       new SelectAttribute('', '', $ldapName.'_app', $required),
       new SelectAttribute('', '', $ldapName.'_role', $required)
     );
+
+
     parent::__construct($description, $ldapName, $attributes, '/^{(.*)}(.*)$/', '{%s}%s', $acl, $label);
     $this->setLinearRendering(TRUE);
 
-//   $allApplications = objects::ls('webapplications',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
-//    var_dump($allApplications);
+   // $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
+   //$allApplications = objects::ls('webApplication');
+    //var_dump($allApplications);
+    //var_dump(objects);
 
 //    $allchoices=array();
 //    $allRolesCode=array();
@@ -153,6 +158,41 @@ class applicationAccount extends simplePlugin
   var $myclient	= '';
   
   private $mainSectionAttrs = array();
+
+
+
+  function getApplicationsRoles()
+  {
+    $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
+    //var_dump($allApplications);
+
+    $allchoices=array();
+    $allRolesCode=array();
+    $allRolesDesc=array();
+    foreach($allApplications as $key => $value){
+            $allRolesCode=[];
+	    $allRolesDesc=[];
+	    foreach( $value['fdApplicationAvailablesRoles'] as $k => $v){
+		    //print("val : ".$v);
+                    $splitRoles=explode("|",$v);
+                    $allRolesCode[]=$splitRoles[0];
+		    $allRolesDesc[]=$splitRoles[1];
+		    //print("\nval :".$splitRoles[0]. " => ".$splitRoles[1]);
+	    }
+	print("<br>");
+	    var_dump($allRolesCode);
+	    print("<br>");
+	var_dump($allRolesDesc);
+        $allchoices[]=array($value['cn'] =>array($allRolesCode,$allRolesDesc));
+    }
+
+    var_dump($allchoices);
+    /* Get List of server with LDAP service */
+/*    return objects::ls('server', NULL, NULL, '(objectClass=goLdapServer)');*/
+  }
+  
+
+
   
   static function plInfo()
   {
@@ -176,6 +216,8 @@ class applicationAccount extends simplePlugin
   */
   static function getAttributesInfo ()
   {
+
+
     return array (
       'main' => array (
         'name'  => _('Applications account'),
@@ -185,9 +227,9 @@ class applicationAccount extends simplePlugin
               _('Roles per each applications'),
               'fdApplicationRoles',
               array(
-                new applicationSelectAttribute(
+                new ApplicationSelectAttribute(
                   _('Roles'), _('Applications Roles - roles available for each applications'),
-                  'fdApplicationRoles', FALSE, 'webApplication'
+                  'fdApplicationRoles', TRUE, 'webApplication'
                   ),
                 )
               ),
@@ -212,6 +254,7 @@ class applicationAccount extends simplePlugin
     # Fetch Seafile Server
     #
     global $config;
+    $this->getApplicationsRoles();
 
     return parent::execute();
   }

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -1,0 +1,112 @@
+<?php
+/*
+  This code is part of FusionDirectory (http://www.fusiondirectory.org/)
+  Copyright (C) 2011-2018  FusionDirectory
+  Copyright (C) 2018  Antoine Gallavardin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+
+/*!
+  \brief   seafile plugin
+
+  This class provides the functionality to read and write all informations 
+  for creating / editing / deleting remote seafiel account.
+
+ */
+ 
+ 
+
+
+class applicationAccount extends simplePlugin
+{
+  var $displayHeader  = TRUE;
+  var $objectclasses  = array('fdApplicationAccount');
+  var $myclient	= '';
+  
+  private $mainSectionAttrs = array();
+  
+  static function plInfo()
+  {
+    return array(
+      'plShortName'     => _('Applications'),
+      'plDescription'   => _('applications settings'),
+      'plIcon'          => 'geticon.php?context=applications&icon=seafile&size=48',
+      'plSmallIcon'     => 'geticon.php?context=applications&icon=seafile&size=16',
+      'plDepends'       => array(),
+      'plSelfModify'    => FALSE,
+      'plPriority'      => 4,
+      'plObjectType'    => array('user'),
+      'plProvidedAcls'  => parent::generatePlProvidedAcls(static::getAttributesInfo()),
+      'plForeignKeys'  => array(
+      )
+    );
+  }
+
+  /*!
+  *  \brief The main function : information about attributes
+  */
+  static function getAttributesInfo ()
+  {
+    return array (
+      'main' => array (
+        'name'  => _('Applications account'),
+        'attrs' => array (
+      
+          new CompositeAttribute (
+            _('Informations for ftp login'),
+              'ftpLoginInfo',
+            array(
+              new StringAttribute (_('Login'),    _('Login for FTP'),     'ftpLogin'),
+              new StringAttribute (_('Password'), _('Password for FTP'),  'ftpPassword'),
+              new StringAttribute (_('Host'),     _('Host for FTP'),      'ftpHost'),
+              new IntAttribute    (_('Port'),     _('Port for FTP'),      'ftpPort', FALSE, 0, FALSE, 21),
+            ),
+          'ftp://%[^@:]:%[^@:]@%[^@:]:%d', // sscanf format
+          'ftp://%s:%s@%s:%d'              // sprintf format
+        ),
+      ),
+    );
+  }
+
+
+  function execute()
+  {
+    $smarty = get_smarty();
+
+    #
+    # Fetch Seafile Server
+    #
+    global $config;
+
+    return parent::execute();
+  }
+  
+
+
+
+  function prepare_save(){
+	parent::prepare_save();
+	global $config;
+	
+}
+
+
+
+
+}
+
+?>

--- a/applications/personal/applications/class_applicationAccount.inc
+++ b/applications/personal/applications/class_applicationAccount.inc
@@ -39,7 +39,7 @@ class ApplicationSelectAttribute extends CompositeAttribute
 
   function __construct($label, $description, $ldapName, $required, $filename, $acl = "")
   {
-    //global $config;
+    global $config;
     $attributes = array(
       new SelectAttribute('', '', $ldapName.'_app', $required),
       new SelectAttribute('', '', $ldapName.'_role', $required)
@@ -48,6 +48,28 @@ class ApplicationSelectAttribute extends CompositeAttribute
 
     parent::__construct($description, $ldapName, $attributes, '/^{(.*)}(.*)$/', '{%s}%s', $acl, $label);
     $this->setLinearRendering(TRUE);
+    /* list of entity stored in LDAP tree */
+    $ldap = $config->get_ldap_link();
+    $ldap->cd($config->current['BASE']);
+    $ldap->search('(objectClass=fdWebApplication)', array('cn', 'fdApplicationAvailablesRoles'));
+
+    //parcours des ebregistremens
+    while ($attrs = $ldap->fetch()) {
+      if (isset($attrs['cn'][0])) {
+	 $app = $attrs['cn'][0];
+	 $allRolesCode=[];
+	 $allRolesDesc=[];
+	foreach($attrs['fdApplicationAvailablesRoles'] as $val){
+		$splitRoles=explode('|',$val);
+		$allRolesCode[]=$splitRoles[0];
+		$allRolesDesc[]=$splitRoles[1];
+	        	
+	}
+      }
+      $allchoices[$app]=array($allRolesCode,$allRolesDesc);
+    }
+    print_r($allchoices);
+    print_r("<br>");
 
    // $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
    //$allApplications = objects::ls('webApplication');
@@ -74,9 +96,12 @@ class ApplicationSelectAttribute extends CompositeAttribute
 
     /*  $this->applicationChoices = FIXME: list des application */
     /* a requeter depsui la bracnhe */
+    $this->applicationChoices = $allchoices;
 
-    $this->applicationChoices = array("color" => array(array("blue", "red", "green"),array("bleu","rouge","vert")),
-	    			      "size" => array(array("small", "medium", "large"),array("petit","moyen","grand")));
+    //$this->applicationChoices = array("color" => array(array("blue", "red", "green"),array("bleu","rouge","vert")),
+//	    "size" => array(array("small", "medium", "large"),array("petit","moyen","grand")));
+
+    print_r($this->applicationChoices);
     
     if (!$required) {
       $this->applicationChoices[''] = array(array(''), array(_('None')));
@@ -160,7 +185,7 @@ class applicationAccount extends simplePlugin
   private $mainSectionAttrs = array();
 
 
-
+/*
   function getApplicationsRoles()
   {
     $allApplications = objects::ls('webApplication',array('cn'=>1,'fdApplicationTitle' => 1, 'fdApplicationAvailablesRoles' => '*' ),NULL,'(objectClass=fdWebApplication)');
@@ -179,17 +204,20 @@ class applicationAccount extends simplePlugin
 		    $allRolesDesc[]=$splitRoles[1];
 		    //print("\nval :".$splitRoles[0]. " => ".$splitRoles[1]);
 	    }
-	print("<br>");
-	    var_dump($allRolesCode);
-	    print("<br>");
-	var_dump($allRolesDesc);
+//	print("<br>");
+//	    var_dump($allRolesCode);
+//	    print("<br>");
+//	var_dump($allRolesDesc);
         $allchoices[]=array($value['cn'] =>array($allRolesCode,$allRolesDesc));
     }
 
-    var_dump($allchoices);
+    return $allchoices;
+    //var_dump($allchoices);
     /* Get List of server with LDAP service */
 /*    return objects::ls('server', NULL, NULL, '(objectClass=goLdapServer)');*/
-  }
+/*
+}
+*/
   
 
 
@@ -213,7 +241,9 @@ class applicationAccount extends simplePlugin
 
   /*!
   *  \brief The main function : information about attributes
-  */
+   */
+
+
   static function getAttributesInfo ()
   {
 
@@ -254,7 +284,6 @@ class applicationAccount extends simplePlugin
     # Fetch Seafile Server
     #
     global $config;
-    $this->getApplicationsRoles();
 
     return parent::execute();
   }

--- a/applications/personal/applications/main.inc
+++ b/applications/personal/applications/main.inc
@@ -1,0 +1,24 @@
+<?php
+
+/*
+  This code is part of FusionDirectory (http://www.fusiondirectory.org/)
+  Copyright (C) 2011-2018  FusionDirectory
+  Copyright (C) 2018  Antoine Gallavardin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+applicationAccount::mainInc('applicationAccount', $ui->dn);
+?>


### PR DESCRIPTION
### Description
this PR allow to declare some profil with code and description and apply to user

- a list of profile to filled is sugestted when creating a web application
![app-set-profil](https://user-images.githubusercontent.com/17747269/50539189-7d723e00-0b7c-11e9-8b6e-ea6b493990d1.png)
- a profile could be assigned to a user by selecting it trough drop down list
![user-profil](https://user-images.githubusercontent.com/17747269/50539199-a1ce1a80-0b7c-11e9-97f5-02ded275ec02.png)

It has been develop for 1.4-dev version  but it could be backport to 1.3
### Why ?
By setting applications profiles inside user record, it's more easy to declare habilitations to external applications MYAPP : juste add a filter  like : '(fdApplicationProfiles={MYAPP}*)' for selecting all users authorized to access to MYAPP, MYAPP could get the profil code set after {MYAPP}  for applying some rights on application. 
Those fields is more easy to use in case of WebSSO like Lemonldap::NG
